### PR TITLE
[TASK-####]

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.5.0'
     id 'io.spring.dependency-management' version '1.1.7'
+    id 'com.google.protobuf' version '0.9.4'
 }
 
 group = 'guru.qa'
@@ -15,6 +16,14 @@ java {
 
 repositories {
     mavenCentral()
+    maven { url 'https://repo.spring.io/milestone' }
+    maven { url 'https://repo.spring.io/snapshot' }
+}
+
+dependencyManagement {
+    imports {
+        mavenBom 'org.springframework.grpc:spring-grpc-dependencies:0.4.0-SNAPSHOT'
+    }
 }
 
 dependencies {
@@ -31,8 +40,34 @@ dependencies {
     testImplementation "com.h2database:h2:2.3.232"
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    implementation 'org.springframework.grpc:spring-grpc-spring-boot-starter'
+    implementation "com.google.protobuf:protobuf-java-util:${dependencyManagement.importedProperties['protobuf-java.version']}"
+    implementation 'io.grpc:grpc-services'
+    implementation "io.grpc:grpc-stub:${dependencyManagement.importedProperties['grpc.version']}"
+    implementation "io.grpc:grpc-protobuf:${dependencyManagement.importedProperties['grpc.version']}"
+    implementation "io.grpc:grpc-netty-shaded:${dependencyManagement.importedProperties['grpc.version']}"
 }
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+protobuf {
+    protoc {
+        artifact = "com.google.protobuf:protoc:${dependencyManagement.importedProperties['protobuf-java.version']}"
+    }
+    plugins {
+        grpc {
+            artifact = "io.grpc:protoc-gen-grpc-java:${dependencyManagement.importedProperties['grpc.version']}"
+        }
+    }
+    generateProtoTasks {
+        all()*.plugins {
+            grpc {
+                option 'jakarta_omit'
+                option '@generated=omit'
+            }
+        }
+    }
 }

--- a/src/main/java/guru/qa/countrycatalogue/service/GrpcCountrycatalogService.java
+++ b/src/main/java/guru/qa/countrycatalogue/service/GrpcCountrycatalogService.java
@@ -1,0 +1,99 @@
+package guru.qa.countrycatalogue.service;
+
+import com.google.protobuf.Empty;
+import guru.qa.countrycatalogue.model.graphql.CountryGql;
+import guru.qa.countrycatalogue.model.graphql.CountryInputGql;
+import guru.qa.grpc.countrycatalog.*;
+import io.grpc.stub.StreamObserver;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+
+@Service
+public class GrpcCountrycatalogService extends CountrycatalogServiceGrpc.CountrycatalogServiceImplBase {
+
+    private final CountryService countryService;
+
+
+    public GrpcCountrycatalogService(CountryService countryService) {
+        this.countryService = countryService;
+    }
+
+    @Override
+    public void addCountry(CountryRequest request, StreamObserver<CountryResponse> responseObserver) {
+        CountryGql countryGql = countryService.addGqlCountry(
+                new CountryInputGql(
+                        request.getName(),
+                        request.getCode()
+                )
+        );
+
+        responseObserver.onNext(CountryResponse.newBuilder()
+                .setCode(countryGql.code())
+                .setName(countryGql.name())
+                .build());
+        responseObserver.onCompleted();
+    }
+
+    @Override
+    public StreamObserver<CountryRequest> addCountries(StreamObserver<CountResponse> responseObserver) {
+        AtomicInteger count = new AtomicInteger();
+
+        return new StreamObserver<>() {
+
+            @Override
+            public void onNext(CountryRequest countryRequest) {
+                countryService.addGqlCountry(
+                        new CountryInputGql(
+                                countryRequest.getCode(),
+                                countryRequest.getName()
+                        )
+                );
+
+                count.incrementAndGet();
+            }
+
+            @Override
+            public void onError(Throwable throwable) {
+                responseObserver.onError(throwable);
+            }
+
+            @Override
+            public void onCompleted() {
+                CountResponse response = CountResponse.newBuilder()
+                        .setCount(count.get())
+                        .build();
+                responseObserver.onNext(response);
+                responseObserver.onCompleted();
+            }
+        };
+    }
+
+    @Override
+    public void updateCountry(CountryUpdateRequest request, StreamObserver<CountryResponse> responseObserver) {
+        CountryGql updatedCountry = countryService.updateCountryNameGql(request.getCode(), request.getName());
+
+        responseObserver.onNext(
+                CountryResponse.newBuilder()
+                        .setCode(updatedCountry.code())
+                        .setName(updatedCountry.name())
+                        .build()
+        );
+        responseObserver.onCompleted();
+    }
+
+    @Override
+    public void getAll(Empty request, StreamObserver<CountriesResponse> responseObserver) {
+        CountriesResponse response = CountriesResponse.newBuilder()
+                .addAllAllCountries(countryService.getAll().stream()
+                        .map(countryJson -> CountryResponse.newBuilder()
+                                .setCode(countryJson.code())
+                                .setName(countryJson.name())
+                                .build()
+                        ).toList()
+                ).build();
+        responseObserver.onNext(response);
+        responseObserver.onCompleted();
+    }
+}

--- a/src/main/proto/countrycatalog.proto
+++ b/src/main/proto/countrycatalog.proto
@@ -1,0 +1,39 @@
+syntax = "proto3";
+
+import "google/protobuf/empty.proto";
+
+package guru.qa.grpc.countrycatalog;
+
+option java_multiple_files = true;
+option java_package = "guru.qa.grpc.countrycatalog";
+option java_outer_classname = "CountrycatalogProto";
+
+service CountrycatalogService {
+  rpc AddCountry(CountryRequest) returns (CountryResponse) {}
+  rpc AddCountries (stream CountryRequest) returns (CountResponse) {}
+  rpc UpdateCountry(CountryUpdateRequest) returns (CountryResponse) {}
+  rpc GetAll(google.protobuf.Empty) returns (CountriesResponse) {}
+}
+
+message CountryRequest {
+  string name = 1;
+  string code = 2;
+}
+
+message CountryUpdateRequest {
+  string code = 1;
+  string name = 2;
+}
+
+message CountryResponse {
+  string name = 2;
+  string code = 3;
+}
+
+message CountriesResponse {
+  repeated CountryResponse allCountries = 1;
+}
+
+message CountResponse {
+  uint32 count = 1;
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,4 +1,8 @@
 spring:
+  grpc:
+    server:
+      servlet:
+        enabled: false
 application:
   name: countrycatalog
   graphql:


### PR DESCRIPTION
Add gRPC service implementation for country operations

- Integrated gRPC support into Spring Boot application
- Added protobuf plugin and dependencies in build.gradle
- Implemented gRPC service with four methods: • AddCountry (unary RPC for single country creation) • AddCountries (client streaming for bulk country creation) • UpdateCountry (unary RPC for country name updates) • GetAll (unary RPC to fetch all countries)
- Defined service contract in countrycatalog.proto file
- Configured protobuf code generation in build script
- Added required repositories and dependency management for gRPC
- Disabled gRPC servlet in application.yaml configuration